### PR TITLE
Fix Unity registry lookup and working directory handling

### DIFF
--- a/~js/run-unity-tests.js
+++ b/~js/run-unity-tests.js
@@ -12,13 +12,16 @@ function GetUnityEditorPath(version) {
     version = version.trim();
     console.log('Unity version:', version);
     let unityVersion = version;
-    // set cwd
-    process.cwd(__dirname);
-    exec(`cmd /c reg query "HKEY_LOCAL_MAHCINE\\SOFTWARE\\Unity Technologies\\Installer\\${unityVersion}" /v "Location x64"`, 
+    // set cwd so child processes run in this directory
+    process.chdir(__dirname);
+    exec(`cmd /c reg query "HKEY_LOCAL_MACHINE\\SOFTWARE\\Unity Technologies\\Installer\\${unityVersion}" /v "Location x64"`,
         options, (err, stdout, stderr) => {
-        if (err || stderr) {
-            console.error(`Error installing winreg: ${err}`);
-            console.error(`stderr: ${stderr}`);
+        if (err) {
+            console.error(`Failed to query Unity Editor path from registry: ${err.message}`);
+            return;
+        }
+        if (stderr) {
+            console.error(`Registry query stderr: ${stderr}`);
             return;
         }
 


### PR DESCRIPTION
## Summary
- query correct Unity registry path and handle errors clearly
- change to script directory so child processes spawn correctly

## Testing
- `node '~js/run-unity-tests.js'` *(fails: ENOENT: no such file or directory, open 'ProjectSettings/ProjectVersion.txt')*

------
https://chatgpt.com/codex/tasks/task_e_688fe66c8e8c8324b723b4331eb4ff2c