### PR TITLE
feat: make listener port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,13 @@ Also
 - Allows you to run playmode or editmode tests with an optional `--category` filter
 - Override the detected Unity editor path using `--unityPath <path>` when needed
 - You can specifically run the `EditMode` test category `LefthookCore` to enforce your project is compiling locally and the installation of this tool is correct.
+- If your Unity instance uses a custom port for the Git hook listener, supply `--port <port>` or set the `UNITY_GITHOOKS_PORT` environment variable so the script can reach it.
 
 #### apply-lfs-plugin-module
 - Used to apply a git plugin that will pull LFS files from a local folder rather than a remote repo. Combined with RClone this can be very effective for large project storage.
 
 
+
+### Changing the listener port
+
+By default Unity Git Hooks listens on port `8080`. If this port is unavailable, open Unity's Preferences (Edit > Preferences on Windows or Unity > Preferences on macOS), select **Unity Git Hooks**, and adjust the **Port** value. When invoking `run-unity-tests.js`, ensure the same port is used by passing `--port <port>` or setting the `UNITY_GITHOOKS_PORT` environment variable.

--- a/Scripts/Editor/GitHookHttpListener.cs
+++ b/Scripts/Editor/GitHookHttpListener.cs
@@ -17,7 +17,8 @@ public class GitHookHttpListener : ICallbacks
     public void Start()
     {
         listener = new HttpListener();
-        listener.Prefixes.Add("http://localhost:8080/");
+        var port = GitHookPreferences.Port;
+        listener.Prefixes.Add($"http://localhost:{port}/");
         listener.Start();
 
         cancellationTokenSource = new CancellationTokenSource();

--- a/Scripts/Editor/GitHookPreferences.cs
+++ b/Scripts/Editor/GitHookPreferences.cs
@@ -1,0 +1,24 @@
+using UnityEditor;
+
+static class GitHookPreferences
+{
+    private const string PortKey = "UnityGitHooks_Port";
+
+    public static int Port
+    {
+        get => EditorPrefs.GetInt(PortKey, 8080);
+        set => EditorPrefs.SetInt(PortKey, value);
+    }
+
+    [SettingsProvider]
+    public static SettingsProvider CreateSettingsProvider()
+    {
+        return new SettingsProvider("Preferences/Unity Git Hooks", SettingsScope.User)
+        {
+            guiHandler = searchContext =>
+            {
+                Port = EditorGUILayout.IntField("Port", Port);
+            }
+        };
+    }
+}

--- a/Scripts/Editor/GitHookPreferences.cs.meta
+++ b/Scripts/Editor/GitHookPreferences.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 49f263a538514ad3b7df57ac1939fe93
+timeCreated: 1754262312

--- a/~js/run-unity-tests.js
+++ b/~js/run-unity-tests.js
@@ -6,6 +6,7 @@ const rawArgs = process.argv.slice(2);
 const testMode = rawArgs[0];
 let category = "All";
 let unityPathArg = null;
+let port = process.env.UNITY_GITHOOKS_PORT ? parseInt(process.env.UNITY_GITHOOKS_PORT, 10) : 8080;
 
 for (let i = 1; i < rawArgs.length; i++) {
     switch (rawArgs[i]) {
@@ -18,6 +19,12 @@ for (let i = 1; i < rawArgs.length; i++) {
         case "--unityPath":
             if (i + 1 < rawArgs.length) {
                 unityPathArg = rawArgs[i + 1];
+                i++;
+            }
+            break;
+        case "--port":
+            if (i + 1 < rawArgs.length) {
+                port = parseInt(rawArgs[i + 1], 10);
                 i++;
             }
             break;
@@ -97,7 +104,7 @@ function RunUnity(unityPath, projectPath) {
         const http = require('http');
         const options = {
             hostname: 'localhost',
-            port: 8080,
+            port: port,
             headers: {}
         };
 


### PR DESCRIPTION
## Summary
- allow configuring HTTP listener port through Unity preferences
- respect configured port in run-unity-tests.js
- document how to change the listener port and pass it to scripts

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688feaa83a0883248ba4885bb4855715