### PR TITLE
Add configurable git event notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,15 @@ Also
 - Used to apply a git plugin that will pull LFS files from a local folder rather than a remote repo. Combined with RClone this can be very effective for large project storage.
 
 
+#### notify-git-events
+- Sends git event details to a configurable backend API.
+- Configure the API URL and authentication token via `Window > GitHooks > API Config` or environment variables `GIT_HOOKS_API_URL` and `GITHUB_TOKEN`.
+- If no configuration is found, the hook skips without error.
+
+Example `lefthook.yml` usage:
+```
+pre-commit:
+  commands:
+    notify_backend:
+      run: node ./Library/PackageCache/com.frostebite.unitygithooks@VERSION/~js/notify-git-events.js pre-commit
+```

--- a/Scripts/Editor/GitHooksApiConfigWindow.cs
+++ b/Scripts/Editor/GitHooksApiConfigWindow.cs
@@ -1,0 +1,60 @@
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+public class GitHooksApiConfigWindow : EditorWindow
+{
+    private const string ConfigFileName = "gitHooksApiConfig.json";
+    private string apiUrl = string.Empty;
+    private string authToken = string.Empty;
+
+    [MenuItem("Window/GitHooks/API Config")]
+    public static void ShowWindow()
+    {
+        GetWindow<GitHooksApiConfigWindow>("Git Hooks API");
+    }
+
+    private void OnEnable()
+    {
+        var path = GetConfigPath();
+        if (File.Exists(path))
+        {
+            try
+            {
+                var json = File.ReadAllText(path);
+                var cfg = JsonUtility.FromJson<Config>(json);
+                apiUrl = cfg.url;
+                authToken = cfg.token;
+            }
+            catch { }
+        }
+    }
+
+    private void OnGUI()
+    {
+        EditorGUILayout.LabelField("Git Hooks API Settings", EditorStyles.boldLabel);
+        apiUrl = EditorGUILayout.TextField("API URL", apiUrl);
+        authToken = EditorGUILayout.TextField("Auth Token", authToken);
+
+        if (GUILayout.Button("Save"))
+        {
+            var cfg = new Config { url = apiUrl, token = authToken };
+            var json = JsonUtility.ToJson(cfg, true);
+            File.WriteAllText(GetConfigPath(), json);
+            AssetDatabase.Refresh();
+        }
+    }
+
+    private static string GetConfigPath()
+    {
+        var projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+        return Path.Combine(projectRoot, ConfigFileName);
+    }
+
+    [System.Serializable]
+    private class Config
+    {
+        public string url;
+        public string token;
+    }
+}

--- a/Scripts/Editor/GitHooksApiConfigWindow.cs.meta
+++ b/Scripts/Editor/GitHooksApiConfigWindow.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f4b6352e8c247d4a1384f3b4ac49d55
+timeCreated: 1728000000

--- a/~js/notify-git-events.js
+++ b/~js/notify-git-events.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const hook = process.argv[2];
+const cwd = process.cwd();
+const configPath = path.join(cwd, 'gitHooksApiConfig.json');
+let url = process.env.GIT_HOOKS_API_URL;
+let token = process.env.GITHUB_TOKEN;
+
+if (fs.existsSync(configPath)) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    url = url || cfg.url;
+    token = token || cfg.token;
+  } catch (_) {}
+}
+
+if (!token) {
+  try {
+    token = execSync('gh auth token', { encoding: 'utf8' }).trim();
+  } catch (_) {}
+}
+
+if (!url || !token) {
+  process.exit(0);
+}
+
+function git(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8' }).trim();
+  } catch (_) {
+    return '';
+  }
+}
+
+const payload = JSON.stringify({
+  event: hook,
+  commit: git('git rev-parse HEAD'),
+  branch: git('git rev-parse --abbrev-ref HEAD'),
+  repoPath: cwd
+});
+
+const http = url.startsWith('https') ? require('https') : require('http');
+const req = http.request(url, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`
+  }
+}, res => {
+  res.on('data', () => {});
+});
+
+req.on('error', err => {
+  console.error('Failed to notify backend:', err.message);
+});
+
+req.write(payload);
+req.end();

--- a/~js/notify-git-events.js.meta
+++ b/~js/notify-git-events.js.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d13c7ad5a9b045cbbf8461b530d3c70c
+timeCreated: 1728000000


### PR DESCRIPTION
## Summary
- Add Unity editor window to configure API URL and auth token for git hook notifications
- Provide notify-git-events.js script to post hook data with GitHub auth token fallback
- Document usage of configurable API notifications and sample lefthook.yml entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `node ~js/notify-git-events.js pre-commit` *(fails: gh: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fe4734ea08324892df8baf8089ba6