### PR TITLE
feat: add named args for unity test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ https://github.com/evilmartians/lefthook
 2) Example workflow
   ```
   pre-commit:
-  parallel: false
-  commands:
-    init_unity_lefthook:
-      run: node ./Library/PackageCache/com.frostebite.unitygithooks@0037422a62/~js/init-unity-lefthook.js
-    run_unity_tests_lefthook:
-      run: node ./Library/PackageCache/com.frostebite.unitygithooks@0037422a62/~js/run-unity-tests.js EditMode LefthookCore
+    parallel: false
+    commands:
+      init_unity_lefthook:
+        run: "node ./Library/PackageCache/com.frostebite.unitygithooks@*/~js/init-unity-lefthook.js"
+      run_unity_tests_lefthook:
+        run: "node ./Library/PackageCache/com.frostebite.unitygithooks@*/~js/run-unity-tests.js EditMode --category LefthookCore"
   ```
+  *The `*` wildcard resolves the package's versioned directory so the path remains valid when the package updates.*
 3) push your new `lefthook.yml` for other project contributors to git!
 
 Also
@@ -81,7 +82,8 @@ Also
 - required, installs required NPM modules for Unity Lefthook.
 
 #### run-unity-tests
-- Allows you to run playmode or editmode tests with a category filter
+- Allows you to run playmode or editmode tests with an optional `--category` filter
+- Override the detected Unity editor path using `--unityPath <path>` when needed
 - You can specifically run the `EditMode` test category `LefthookCore` to enforce your project is compiling locally and the installation of this tool is correct.
 
 #### apply-lfs-plugin-module

--- a/~js/run-unity-tests.js
+++ b/~js/run-unity-tests.js
@@ -1,8 +1,33 @@
-﻿const fs = require('fs');
+const fs = require('fs');
 const {exec} = require("child_process");
 
+// Parse named arguments
+const rawArgs = process.argv.slice(2);
+const testMode = rawArgs[0];
+let category = "All";
+let unityPathArg = null;
+
+for (let i = 1; i < rawArgs.length; i++) {
+    switch (rawArgs[i]) {
+        case "--category":
+            if (i + 1 < rawArgs.length) {
+                category = rawArgs[i + 1];
+                i++;
+            }
+            break;
+        case "--unityPath":
+            if (i + 1 < rawArgs.length) {
+                unityPathArg = rawArgs[i + 1];
+                i++;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
 function GetUnityEditorPath(version) {
-    
+
     // install winreg npm
     // install winreg in the script dir
     var options = {
@@ -26,7 +51,7 @@ function GetUnityEditorPath(version) {
         }
 
         let unityPath = null;
-        
+
         // parse stdout
         let lines = stdout.split('\n');
         lines.forEach(item => {
@@ -44,9 +69,9 @@ function GetUnityEditorPath(version) {
             }
         }
         );
-        
-        if (process.argv[3] != null && unityPath == null) {
-            unityPath = process.argv[3];
+
+        if (unityPathArg != null && unityPath == null) {
+            unityPath = unityPathArg;
             console.log('Using Unity Editor path from command line: ', unityPath);
         }
 
@@ -59,16 +84,15 @@ function GetUnityEditorPath(version) {
         RunUnity(unityPath, '.');
         return;
     });
-    
-}
 
+}
 
 function RunUnity(unityPath, projectPath) {
     console.log('Running Unity: ', unityPath);
-    
+
     // handle path with spaces
     unityPath = `"${unityPath}"`;
-    
+
         // http get http://localhost:8080/ and log results
         const http = require('http');
         const options = {
@@ -77,20 +101,15 @@ function RunUnity(unityPath, projectPath) {
             headers: {}
         };
 
-// Add headers including repo path
+    // Add headers including repo path
     options.headers['repoPath'] = projectPath;
-    options.headers['testMode'] = process.argv[2];
-
-    let category = "All";
-    if (process.argv.length > 3) {
-        category = process.argv[3];
-    }
+    options.headers['testMode'] = testMode;
     options.headers['testCategory'] = category;
-        
-        
+
+
         const req = http.get(options, (res) => {
             console.log(`statusCode: ${res.statusCode}`);
-            
+
             res.on('data', (d) => {
                 process.stdout.write("data: "+ d);
                 if(d.includes('Tests failed')) {
@@ -101,10 +120,9 @@ function RunUnity(unityPath, projectPath) {
         });
         req.on('error', (error) => {
             // run unity with command line args batchmode, nographics, run tests
-            exec(`${unityPath} -projectPath \"${projectPath}\" -runTests -testPlatform ${process.argv[2]} -logFile \"-\"`, (err, stdout, stderr) => {
+            exec(`${unityPath} -projectPath \"${projectPath}\" -runTests -testPlatform ${testMode} -logFile \"-\"`, (err, stdout, stderr) => {
                 if (err) {
                     console.error(`Error running Unity: ${err}`);
-
 
                     return;
                 }
@@ -112,7 +130,7 @@ function RunUnity(unityPath, projectPath) {
                 console.log(`stderr: ${stderr}`);
             });
         });
-    
+
 }
 
 // read unity project version
@@ -122,7 +140,6 @@ fs.readFile('ProjectSettings/ProjectVersion.txt', 'utf8', (err, data) => {
         return;
     }
 
-    
     // get m_EditorVersion
     let lines = data.split('\n');
     for (let line of lines) {
@@ -132,5 +149,5 @@ fs.readFile('ProjectSettings/ProjectVersion.txt', 'utf8', (err, data) => {
             GetUnityEditorPath(version);
         }
     }
-    
+
 });


### PR DESCRIPTION
## Summary
- parse `--category` and `--unityPath` arguments in the Unity test runner script
- expose parsed values to the HTTP request and Unity execution
- document new hook usage and options
- document dynamic package path resolution using a wildcard in `lefthook.yml` examples

## Testing
- `npm test` (fails: Missing script "test")
- `node '~js/run-unity-tests.js' EditMode --category Foo --unityPath Bar` (fails: ENOENT ProjectSettings/ProjectVersion.txt)


------
https://chatgpt.com/codex/tasks/task_e_688fe8ea073c832497a7ae3badec29e5