### PR TITLE
Fix Debug reference

### DIFF
--- a/Scripts/Editor/LeftHookWindow.cs
+++ b/Scripts/Editor/LeftHookWindow.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 public class LeftHookWindow : EditorWindow
 {


### PR DESCRIPTION
## Summary
- resolve ambiguous `Debug` reference by aliasing `UnityEngine.Debug`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6890070941f083248332408ae3a3084e