### PR TITLE
Improve git hook health visibility in editor

### DIFF
--- a/Scripts/Editor/LeftHookWindow.cs
+++ b/Scripts/Editor/LeftHookWindow.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -9,6 +10,10 @@ public class LeftHookWindow : EditorWindow
 {
     private bool isRunning;
     private string statusMessage = string.Empty;
+    private bool lefthookInstalled;
+    private bool repoHooksInstalled;
+    private bool listenerRunning;
+    private string lefthookVersion = string.Empty;
 
     [MenuItem("Window/GitHooks/Install Window")]
     public static void ShowWindow()
@@ -21,8 +26,23 @@ public class LeftHookWindow : EditorWindow
         }
     }
 
+    private void OnEnable()
+    {
+        CheckStatus();
+    }
+
     private void OnGUI()
     {
+        EditorGUILayout.LabelField("Lefthook", lefthookInstalled ? $"Installed ({lefthookVersion})" : "Not installed");
+        EditorGUILayout.LabelField("Config", repoHooksInstalled ? "Found" : "Missing");
+        EditorGUILayout.LabelField("Listener", listenerRunning ? "Running" : "Stopped");
+
+        if (GUILayout.Button("Refresh Status"))
+        {
+            CheckStatus();
+        }
+
+        EditorGUILayout.Space();
         EditorGUILayout.LabelField(statusMessage);
 
         EditorGUI.BeginDisabledGroup(isRunning);
@@ -35,6 +55,25 @@ public class LeftHookWindow : EditorWindow
         {
             RunCommand("lefthook", "install");
         }
+
+        EditorGUI.BeginDisabledGroup(UnityLefthook.Listener == null);
+        if (listenerRunning)
+        {
+            if (GUILayout.Button("Stop Listener"))
+            {
+                UnityLefthook.Listener.Stop();
+                CheckStatus();
+            }
+        }
+        else
+        {
+            if (GUILayout.Button("Start Listener"))
+            {
+                UnityLefthook.Listener.Start();
+                CheckStatus();
+            }
+        }
+        EditorGUI.EndDisabledGroup();
 
         if (GUILayout.Button("Close"))
         {
@@ -115,7 +154,58 @@ public class LeftHookWindow : EditorWindow
         {
             isRunning = false;
             Repaint();
+            CheckStatus();
         }
+    }
+
+    private async void CheckStatus()
+    {
+        isRunning = true;
+        statusMessage = "Checking status...";
+        Repaint();
+
+        await Task.Run(() =>
+        {
+            lefthookInstalled = TryGetLefthookVersion(out lefthookVersion);
+            var projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            repoHooksInstalled = File.Exists(Path.Combine(projectRoot, "lefthook.yml"));
+            listenerRunning = UnityLefthook.Listener != null && UnityLefthook.Listener.IsRunning;
+        });
+
+        statusMessage = string.Empty;
+        isRunning = false;
+        Repaint();
+    }
+
+    private bool TryGetLefthookVersion(out string version)
+    {
+        version = string.Empty;
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "lefthook",
+                Arguments = "version",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            using (var process = Process.Start(startInfo))
+            {
+                process?.WaitForExit();
+                if (process != null && process.ExitCode == 0)
+                {
+                    version = process.StandardOutput.ReadToEnd().Trim();
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary
- display Lefthook, config and listener status in LeftHookWindow
- allow starting/stopping the git hook listener
- expose IsRunning and Stop methods on GitHookHttpListener

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68910cec3fbc8324b226d60c6824f60f